### PR TITLE
AWS SecurityAudit IAM policy no longer has cloudwatch:ListTagsForReso…

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ hand-crafted policy, an exact policy that includes
         "batch:Describe*",
         "batch:List*",
         "cloudwatch:GetMetricData",
+        "cloudwatch:List*",
         "dynamodb:Describe*",
         "dynamodb:List*",
         "ecr:Describe*",

--- a/cloudformation/iam-cloudformation.json
+++ b/cloudformation/iam-cloudformation.json
@@ -49,6 +49,7 @@
                 "batch:Describe*",
                 "batch:List*",
                 "cloudwatch:GetMetricData",
+                "cloudwatch:List*",
                 "dynamodb:Describe*",
                 "dynamodb:List*",
                 "ecr:Describe*",


### PR DESCRIPTION
…urce permission. Adding it to the custom policy and readme