### PR TITLE
Add EC2 Instance events

### DIFF
--- a/cloudformation/events-cloudformation.json
+++ b/cloudformation/events-cloudformation.json
@@ -32,10 +32,14 @@
         "Name": "jupiterone-cloudtrail-events",
         "Description": "Send CloudTrail Events to JupiterOne",
         "EventPattern": {
-          "source": ["aws.s3", "aws.iam"],
+          "source": ["aws.s3", "aws.iam", "aws.ec2"],
           "detail-type": ["AWS API Call via CloudTrail"],
           "detail": {
-            "eventSource": ["s3.amazonaws.com", "iam.amazonaws.com"],
+            "eventSource": [
+              "s3.amazonaws.com",
+              "iam.amazonaws.com",
+              "ec2.amazonaws.com"
+            ],
             "eventName": [
               "CreateBucket",
               "DeleteBucket",
@@ -46,7 +50,6 @@
               "DeleteBucketTagging",
               "PutBucketAcl",
               "PutBucketEncryption",
-              "DeleteBucketEncryption",
               "PutBucketInventoryConfiguration",
               "PutBucketLifecycle",
               "PutBucketLogging",
@@ -111,7 +114,10 @@
               "UpdateRole",
               "UpdateRoleDescription",
               "UpdateSAMLProvider",
-              "UpdateUser"
+              "UpdateUser",
+              "RunInstances",
+              "StopInstances",
+              "TerminateInstances"
             ]
           }
         },


### PR DESCRIPTION
Although we're only ingesting `RunInstances` at the moment, I added `RunInstances, StopInstances, TerminateInstances` events here. I noticed that we provision many more events in this CloudFront template than we yet ingest, and I expect that's just so we don't require customers to update their environments with this template _constantly_. 

Maybe that means there should be _more_ events provisioned here... 