### PR TITLE
Add the StartInstances event

### DIFF
--- a/cloudformation/events-cloudformation.json
+++ b/cloudformation/events-cloudformation.json
@@ -116,6 +116,7 @@
               "UpdateSAMLProvider",
               "UpdateUser",
               "RunInstances",
+              "StartInstances",
               "StopInstances",
               "TerminateInstances"
             ]


### PR DESCRIPTION
Because customers must update their environments every time there is a change to what events we ingest, it might make sense to ingest all events from a specific service (ex: `aws.ec2`) rather than naming specific events.  This gives J1 more leeway on what events it can handle without needing to update this project as much.

[EventPattern Documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/filtering-examples-structure.html)