### PR TITLE
Update iam-cloudformation.json - remove wafv2

### DIFF
--- a/cloudformation/iam-cloudformation.json
+++ b/cloudformation/iam-cloudformation.json
@@ -83,8 +83,6 @@
                 "waf:Get*",
                 "waf-regional:List*",
                 "waf-regional:Get*",
-                "wafv2:Get*",
-                "wafv2:List*",
                 "workspaces:List*"
               ]
             },


### PR DESCRIPTION
we do not need wafv2 get* and list * because they are in the aws managed SecurityAudit policy already and this cloudformation stack attaches that managed policy