### PR TITLE
add tag-get-resources to specific permissions policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ to update the policy in the future as more APIs are called by JupiterOne.
         "sqs:GetQueueAttributes",
         "sqs:ListQueues",
         "sqs:ListQueueTags",
+        "tag:GetResources",
         "transfer:ListServers",
         "transfer:ListTagsForResource",
         "transfer:ListUsers",


### PR DESCRIPTION
A user just noticed that with the specific permissions policy they are hitting an error because this permission is not included. This permission is automatically included in the AWS managed SecurityAudit policy.