### PR TITLE
Add EventBridge IAM Role

### DIFF
--- a/cloudformation/events-cloudformation.json
+++ b/cloudformation/events-cloudformation.json
@@ -27,10 +27,43 @@
     }
   },
   "Resources": {
+    "JupiterOneCloudTrailEventBusRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Effect": "Allow",
+            "Principal":{
+              "Service": ["events.amazonaws.com"]
+            },
+            "Action": ["sts:AssumeRole"]
+          }]
+        },
+        "RoleName": "jupiterone-cloudtrail-events",
+        "Description": "Role allowing EventBridge to forward events to JupiterOne",
+        "Policies": [{
+          "PolicyName": "jupiterone-cloudtrail-events",
+          "PolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [{
+              "Effect": "Allow",
+              "Action": [
+                "events:PutEvents"
+              ],
+              "Resource": [
+                "arn:aws:events:us-east-1:612791702201:event-bus/jupiter-integration-aws"
+              ]
+            }]
+          }
+        }]
+      }
+    },
     "JupiterOneCloudTrailEventsRule": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "Name": "jupiterone-cloudtrail-events",
+        "RoleArn": { "Fn::GetAtt": ["JupiterOneCloudTrailEventBusRole", "Arn"] },
         "Description": "Send CloudTrail Events to JupiterOne",
         "EventPattern": {
           "source": ["aws.s3", "aws.iam", "aws.ec2"],
@@ -42,84 +75,7 @@
               "ec2.amazonaws.com"
             ],
             "eventName": [
-              "CreateBucket",
-              "DeleteBucket",
-              "DeleteBucketEncryption",
-              "DeleteBucketLifecycle",
-              "DeleteBucketPolicy",
-              "DeleteBucketReplication",
-              "DeleteBucketTagging",
-              "PutBucketAcl",
-              "PutBucketEncryption",
-              "PutBucketInventoryConfiguration",
-              "PutBucketLifecycle",
-              "PutBucketLogging",
-              "PutBucketPolicy",
-              "PutBucketReplication",
-              "PutBucketTagging",
-              "PutBucketVersioning",
-              "PutObjectLockConfiguration",
-              "PutPublicAccessBlock",
-              "AddRoleToInstanceProfile",
-              "AddUserToGroup",
-              "AttachGroupPolicy",
-              "AttachRolePolicy",
-              "AttachUserPolicy",
-              "ChangePassword",
-              "CreateAccessKey",
-              "CreateGroup",
-              "CreateInstanceProfile",
-              "CreateLoginProfile",
-              "CreatePolicy",
-              "CreatePolicyVersion",
-              "CreateRole",
-              "CreateSAMLProvider",
-              "CreateServiceLinkedRole",
-              "CreateUser",
-              "CreateVirtualMFADevice",
-              "DeactivateMFADevice",
-              "DeleteAccessKey",
-              "DeleteAccountPasswordPolicy",
-              "DeleteGroup",
-              "DeleteGroupPolicy",
-              "DeleteInstanceProfile",
-              "DeleteLoginProfile",
-              "DeletePolicy",
-              "DeletePolicyVersion",
-              "DeleteRole",
-              "DeleteRolePolicy",
-              "DeleteSAMLProvider",
-              "DeleteServiceLinkedRole",
-              "DeleteUser",
-              "DeleteUserPolicy",
-              "DeleteVirtualMFADevice",
-              "DetachGroupPolicy",
-              "DetachRolePolicy",
-              "DetachUserPolicy",
-              "EnableMFADevice",
-              "PutGroupPolicy",
-              "PutRolePolicy",
-              "PutUserPolicy",
-              "RemoveRoleFromInstanceProfile",
-              "RemoveUserFromGroup",
-              "SetDefaultPolicyVersion",
-              "TagRole",
-              "TagUser",
-              "UntagRole",
-              "UntagUser",
-              "UpdateAccessKey",
-              "UpdateAccountPasswordPolicy",
-              "UpdateAssumeRolePolicy",
-              "UpdateGroup",
-              "UpdateLoginProfile",
-              "UpdateRole",
-              "UpdateRoleDescription",
-              "UpdateSAMLProvider",
-              "UpdateUser",
-              "RunInstances",
-              "StartInstances",
-              "StopInstances",
-              "TerminateInstances"
+              "CreateBucket"
             ]
           }
         },


### PR DESCRIPTION
The existing CF stack to provision an EventBridge rule is failing with:

> Access to the resource arn:aws:events:us-east-1:612791702201:event-bus/jupiter-integration-aws is denied. Reason: EventBus does not exist or its policy does not allow this operation. (Service: AmazonCloudWatchEvents; Status Code: 400; Error Code: AccessDeniedException; Request ID: 0695a4bd-467d-4bf8-8b62-82feeb78241b; Proxy: null)

According to AWS Docs (see https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEvents-CrossAccountEventDelivery.html), 

> the sender account also must have an IAM role with policies that enable it to send events to the receiver account. If you use the AWS Management Console to create the rule that targets the receiver account, this is done automatically. If you use the AWS CLI, you must create the role manually.

The above seems to indicate that our CF stack also needs to add an IAM role to the EventBridge Rule as defined in the linked AWS docs, which this PR does.

However, we _still_ receive the same error message, "**Reason: EventBus does not exist or its policy does not allow this operation**". Any thoughts as to why?

---
Note: this CF template was originally created on June 26, 2020, and ostensibly worked at that point (see commit https://github.com/JupiterOne/jupiterone-aws-cloudformation/commit/16971c267a521177aff6f414d622124f6917e602)