### PR TITLE
Adding Systems Manager (SSM) permissions

### DIFF
--- a/cloudformation/iam-cloudformation.json
+++ b/cloudformation/iam-cloudformation.json
@@ -82,6 +82,7 @@
                 "sns:ListTopics",
                 "sns:ListSubscriptions",
                 "sns:ListTagsForResource",
+                "ssm:Describe*",
                 "waf:List*",
                 "waf:Get*",
                 "waf-regional:List*",


### PR DESCRIPTION
These permissions are needed for the AWS Integration to access Systems Manager (SSM) APIs.